### PR TITLE
p5: backend unit tests, specs, coverage config, and CI workflow

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -1,0 +1,60 @@
+name: Run backend tests
+
+on:
+  push:
+    paths:
+      - 'simple-server/**'
+      - '.github/workflows/run-backend-tests.yml'
+  pull_request:
+    paths:
+      - 'simple-server/**'
+      - '.github/workflows/run-backend-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres123
+          POSTGRES_DB: discord_clone
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      NODE_ENV: test
+      JWT_SECRET: your-super-secret-jwt-key-change-this-in-production
+      JWT_EXPIRES_IN: 7d
+      DATABASE_HOST: localhost
+      DATABASE_PORT: '5432'
+      DATABASE_NAME: discord_clone
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres123
+      DATABASE_URL: postgresql://postgres:postgres123@localhost:5432/discord_clone
+
+    defaults:
+      run:
+        working-directory: simple-server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: npm
+          cache-dependency-path: simple-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest (integration + unit) with coverage
+        run: npm run test:coverage

--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ npm test
 
 More detail: [`simple-server/README.md`](simple-server/README.md).
 
+### P5 — backend unit tests and coverage (no Docker required for this part)
+
+Core auth logic is covered by **isolated Jest tests** that mock the database (`simple-server/tests/userService.unit.test.js`, `simple-server/tests/User.model.unit.test.js`). English test specifications live in [`docs/testing/userService-test-spec.md`](docs/testing/userService-test-spec.md) and [`docs/testing/User-model-test-spec.md`](docs/testing/User-model-test-spec.md).
+
+From the **`simple-server`** directory (Node.js 18+ and `npm install` required):
+
+```bash
+cd simple-server
+npm install
+npx jest userService.unit.test.js User.model.unit.test.js
+```
+
+**Coverage** for `services/userService.js` and `models/User.js` (threshold 80% per file, enforced when coverage is enabled):
+
+```bash
+cd simple-server
+npm run test:coverage
+```
+
+That last command runs **all** backend tests, including integration suites that need PostgreSQL (same rules as above: start Postgres or use Docker). To run **only** the two unit files with coverage:
+
+```bash
+cd simple-server
+npx jest userService.unit.test.js User.model.unit.test.js --coverage
+```
+
 ---
 
 ## **How to Stop**

--- a/docs/testing/User-model-test-spec.md
+++ b/docs/testing/User-model-test-spec.md
@@ -1,0 +1,50 @@
+# Test specification: `simple-server/models/User.js`
+
+## Purpose
+
+The `User` model encapsulates SQL access for user records: create, lookup, profile/status updates, related lists (servers, DMs, friends), and delete. Unit tests mock `pool.query` from `config/database` so tests do not require PostgreSQL.
+
+## Functions under test (static methods)
+
+| Method | Role |
+|--------|------|
+| `User.create(userData)` | INSERT user; map unique violations to domain errors. |
+| `User.findByEmail(email, includePassword?)` | SELECT by email; optionally include `password_hash`. |
+| `User.findByUsername(username)` | SELECT by username. |
+| `User.findById(id)` | SELECT public columns by id. |
+| `User.updateStatus(id, status)` | UPDATE status. |
+| `User.updateProfile(id, updates)` | UPDATE allowed columns; error if none valid. |
+| `User.getServers(userId)` | JOIN servers for member. |
+| `User.getDirectMessages(userId)` | SELECT DM rows for participant. |
+| `User.getFriends(userId)` | SELECT accepted friends. |
+| `User.delete(id)` | DELETE user; return boolean by `rowCount`. |
+
+## Test table
+
+| # | Purpose | Inputs / mock `pool.query` | Expected output / behavior |
+|---|---------|---------------------------|----------------------------|
+| 1 | `create` returns inserted row | Resolves `{ rows: [{ id: '1', username: 'U' }] }` | Resolves to first row; `pool.query` called with INSERT. |
+| 2 | `create` maps username conflict | Rejects with `{ code: '23505', constraint: 'users_username_unique' }` | Rejects `Error('Username already exists')`. |
+| 3 | `create` maps email conflict | Rejects with `{ code: '23505', constraint: 'users_email_unique' }` | Rejects `Error('Email already exists')`. |
+| 4 | `create` rethrows other DB errors | Rejects with `{ code: '23505', constraint: 'other' }` | Rejects with same error. |
+| 5 | `findByEmail` without password | `includePassword = false` | Query text omits raw `SELECT *` password path; returns row. |
+| 6 | `findByEmail` with password | `includePassword = true` | Query is `SELECT *`; returns row with hash. |
+| 7 | `findByUsername` | email-style row | Returns `rows[0]`. |
+| 8 | `findById` | normal row | Returns row. |
+| 9 | `updateStatus` | RETURNING row | Returns updated row. |
+| 10 | `updateProfile` with valid fields | `updates = { display_name: 'X' }` | Builds UPDATE with `display_name`; returns row. |
+| 11 | `updateProfile` rejects empty updates | `updates = { unknown: 1 }` | Rejects `Error('No valid fields to update')`. |
+| 12 | `getServers` | multiple rows | Returns `rows` array. |
+| 13 | `getDirectMessages` | rows | Returns `rows`. |
+| 14 | `getFriends` | rows | Returns `rows`. |
+| 15 | `delete` removes row | `{ rowCount: 1 }` | Resolves `true`. |
+| 16 | `delete` no row | `{ rowCount: 0 }` | Resolves `false`. |
+| 17 | `findByEmail` propagates query failure | `pool.query` rejects | Method rejects with same error. |
+
+## Path / exception coverage goals
+
+- Unique-violation branches in `create`.
+- `updateProfile` guard when no allowed keys.
+- `delete` truthy/falsy `rowCount`.
+
+Target: **≥80%** statement/branch coverage on `models/User.js` when running Jest with coverage for this file.

--- a/docs/testing/userService-test-spec.md
+++ b/docs/testing/userService-test-spec.md
@@ -1,0 +1,39 @@
+# Test specification: `simple-server/services/userService.js`
+
+## Purpose
+
+This module implements core authentication-related business logic: password hashing (internal), demo account seeding, JWT issuance (internal), user registration, login, and simple user lookups. Unit tests mock `User` (database layer), `bcryptjs`, and `jsonwebtoken` so no database or network is required.
+
+## Functions under test (exported)
+
+| Symbol | Role |
+|--------|------|
+| `registerUser(userData)` | Hash password, create user via `User.create`, return `{ user, token }`. |
+| `loginUser(loginData)` | Load user by email (with hash), verify password, return public user + token. |
+| `getUserById(id)` | Delegate to `User.findById`. |
+| `getAllUsers()` | Return empty list (stub for development). |
+| `initializeDemoAccounts()` | If demo email is absent, insert fixed demo users via `User.create`. |
+
+Internal helpers `hashPassword`, `verifyPassword`, and `generateToken` are covered indirectly through the exported functions.
+
+## Test table
+
+| # | Purpose | Inputs | Expected output / behavior |
+|---|---------|--------|---------------------------|
+| 1 | `registerUser` succeeds for valid data | `userData = { username: 'newuser', email: 'new@test.com', password: 'secret12' }`; mock `bcrypt.hash` → `'hash'`; mock `User.create` → created row; mock `jwt.sign` → `'tok'` | Resolves to `{ user: createdRow, token: 'tok' }`; `User.create` called with `passwordHash: 'hash'`. |
+| 2 | `loginUser` succeeds when credentials match | `loginData = { email: 'a@b.com', password: 'x' }`; `User.findByEmail(email, true)` → row with `password_hash`; `bcrypt.compare` → `true`; `User.findByEmail(email, false)` → public user; `jwt.sign` → `'tok'` | Resolves to `{ user: publicUser, token: 'tok' }`. |
+| 3 | `loginUser` throws when email unknown | `findByEmail(..., true)` → `undefined` | Rejects with `Error` message `Invalid email or password`. |
+| 4 | `loginUser` throws when password wrong | User row present; `bcrypt.compare` → `false` | Rejects with `Invalid email or password`. |
+| 5 | `getUserById` delegates | `id = '42'`; `User.findById` → `{ id: '42' }` | Resolves to `{ id: '42' }`. |
+| 6 | `getAllUsers` returns stub | (none) | Resolves to `[]`. |
+| 7 | `initializeDemoAccounts` skips when demo exists | `User.findByEmail('nafisa@example.com')` → `{}` | `User.create` not called. |
+| 8 | `initializeDemoAccounts` seeds when missing | `User.findByEmail` → `null`; `User.create` resolves each time | `User.create` called 5 times with expected demo emails. |
+| 9 | `initializeDemoAccounts` swallows errors | `User.findByEmail` throws `new Error('db down')` | Resolves without throwing; error path exercised (demo init failure). |
+
+## Path / exception coverage goals
+
+- All branches in `loginUser` (missing user, bad password, success).
+- Both branches of `initializeDemoAccounts` (demo present vs absent).
+- `try/catch` in `initializeDemoAccounts` for resilience.
+
+Target: **≥80%** statement/branch coverage on `services/userService.js` when running Jest with coverage for this file.

--- a/simple-server/jest.config.js
+++ b/simple-server/jest.config.js
@@ -2,4 +2,23 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.js'],
   testTimeout: 15000,
+  collectCoverageFrom: [
+    'services/userService.js',
+    'models/User.js',
+  ],
+  coveragePathIgnorePatterns: ['/node_modules/'],
+  coverageThreshold: {
+    './services/userService.js': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    './models/User.js': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/simple-server/package.json
+++ b/simple-server/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon --legacy-watch server.js",
     "test": "jest --runInBand --forceExit --detectOpenHandles",
+    "test:coverage": "jest --runInBand --forceExit --detectOpenHandles --coverage",
     "test:docker": "docker compose -f ../docker-compose.yml run --rm backend sh -c \"npm install && npm test\""
   },
   "devDependencies": {

--- a/simple-server/tests/User.model.unit.test.js
+++ b/simple-server/tests/User.model.unit.test.js
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for models/User.js (see docs/testing/User-model-test-spec.md).
+ * Mocks pg pool — no PostgreSQL.
+ */
+jest.mock('../config/database', () => ({
+  pool: { query: jest.fn() },
+}));
+
+const { pool } = require('../config/database');
+const User = require('../models/User');
+
+describe('User model (unit)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    test('returns inserted row on success', async () => {
+      const row = { id: '1', username: 'U' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await User.create({
+        id: '1',
+        username: 'U',
+        email: 'u@test.com',
+        passwordHash: 'h',
+        displayName: 'U',
+        avatar: 'a',
+      });
+
+      expect(result).toEqual(row);
+      expect(pool.query).toHaveBeenCalled();
+    });
+
+    test('maps username unique violation', async () => {
+      const err = Object.assign(new Error('dup'), {
+        code: '23505',
+        constraint: 'users_username_unique',
+      });
+      pool.query.mockRejectedValue(err);
+
+      await expect(
+        User.create({
+          id: '1',
+          username: 'U',
+          email: 'u@test.com',
+          passwordHash: 'h',
+        })
+      ).rejects.toThrow('Username already exists');
+    });
+
+    test('maps email unique violation', async () => {
+      const err = Object.assign(new Error('dup'), {
+        code: '23505',
+        constraint: 'users_email_unique',
+      });
+      pool.query.mockRejectedValue(err);
+
+      await expect(
+        User.create({
+          id: '1',
+          username: 'U',
+          email: 'u@test.com',
+          passwordHash: 'h',
+        })
+      ).rejects.toThrow('Email already exists');
+    });
+
+    test('rethrows other unique violations on create', async () => {
+      const err = Object.assign(new Error('dup'), {
+        code: '23505',
+        constraint: 'other_constraint',
+      });
+      pool.query.mockRejectedValue(err);
+
+      await expect(
+        User.create({
+          id: '1',
+          username: 'U',
+          email: 'u@test.com',
+          passwordHash: 'h',
+        })
+      ).rejects.toBe(err);
+    });
+
+    test('rethrows non-unique errors', async () => {
+      const err = new Error('connection failed');
+      pool.query.mockRejectedValue(err);
+
+      await expect(
+        User.create({
+          id: '1',
+          username: 'U',
+          email: 'u@test.com',
+          passwordHash: 'h',
+        })
+      ).rejects.toBe(err);
+    });
+  });
+
+  describe('findByEmail', () => {
+    test('uses public projection when includePassword is false', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: '1' }] });
+
+      await User.findByEmail('e@test.com', false);
+
+      const q = pool.query.mock.calls[0][0];
+      expect(q).not.toMatch(/SELECT \*/i);
+      expect(q).not.toMatch(/password_hash/i);
+      expect(q).toContain('WHERE email = $1');
+    });
+
+    test('selects all columns when includePassword is true', async () => {
+      pool.query.mockResolvedValue({ rows: [{ password_hash: 'x' }] });
+
+      await User.findByEmail('e@test.com', true);
+
+      expect(pool.query.mock.calls[0][0]).toMatch(/SELECT \* FROM users/i);
+    });
+
+    test('propagates query failures', async () => {
+      const err = new Error('timeout');
+      pool.query.mockRejectedValue(err);
+
+      await expect(User.findByEmail('x@test.com')).rejects.toBe(err);
+    });
+  });
+
+  describe('findByUsername', () => {
+    test('returns first row', async () => {
+      pool.query.mockResolvedValue({ rows: [{ username: 'bob' }] });
+
+      await expect(User.findByUsername('bob')).resolves.toEqual({
+        username: 'bob',
+      });
+    });
+  });
+
+  describe('findById', () => {
+    test('returns user row', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: '7' }] });
+
+      await expect(User.findById('7')).resolves.toEqual({ id: '7' });
+    });
+  });
+
+  describe('updateStatus', () => {
+    test('returns updated row', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: '1', status: 'online' }] });
+
+      await expect(User.updateStatus('1', 'online')).resolves.toEqual({
+        id: '1',
+        status: 'online',
+      });
+    });
+  });
+
+  describe('updateProfile', () => {
+    test('updates allowed snake_case fields', async () => {
+      pool.query.mockResolvedValue({
+        rows: [{ id: '1', display_name: 'New' }],
+      });
+
+      const row = await User.updateProfile('1', { display_name: 'New' });
+
+      expect(row.display_name).toBe('New');
+      const q = pool.query.mock.calls[0][0];
+      expect(q).toContain('display_name = $1');
+    });
+
+    test('throws when no valid fields', async () => {
+      await expect(
+        User.updateProfile('1', { unknown: 'x' })
+      ).rejects.toThrow('No valid fields to update');
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    test('propagates database errors', async () => {
+      const err = new Error('deadlock');
+      pool.query.mockRejectedValue(err);
+
+      await expect(
+        User.updateProfile('1', { display_name: 'X' })
+      ).rejects.toBe(err);
+    });
+  });
+
+  describe('getServers', () => {
+    test('returns rows from pool', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: 's1' }] });
+
+      await expect(User.getServers('u1')).resolves.toEqual([{ id: 's1' }]);
+    });
+  });
+
+  describe('getDirectMessages', () => {
+    test('returns rows from pool', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: 'dm1' }] });
+
+      await expect(User.getDirectMessages('u1')).resolves.toEqual([
+        { id: 'dm1' },
+      ]);
+    });
+  });
+
+  describe('getFriends', () => {
+    test('returns rows from pool', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: 'f1' }] });
+
+      await expect(User.getFriends('u1')).resolves.toEqual([{ id: 'f1' }]);
+    });
+  });
+
+  describe('delete', () => {
+    test('returns true when a row was deleted', async () => {
+      pool.query.mockResolvedValue({ rowCount: 1 });
+
+      await expect(User.delete('9')).resolves.toBe(true);
+    });
+
+    test('returns false when no row deleted', async () => {
+      pool.query.mockResolvedValue({ rowCount: 0 });
+
+      await expect(User.delete('missing')).resolves.toBe(false);
+    });
+  });
+});

--- a/simple-server/tests/userService.unit.test.js
+++ b/simple-server/tests/userService.unit.test.js
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for services/userService.js (see docs/testing/userService-test-spec.md).
+ * Mocks User model, bcrypt, and jwt — no database.
+ */
+jest.mock('../models/User');
+jest.mock('bcryptjs');
+jest.mock('jsonwebtoken');
+
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const {
+  registerUser,
+  loginUser,
+  getUserById,
+  getAllUsers,
+  initializeDemoAccounts,
+} = require('../services/userService');
+
+describe('userService (unit)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.JWT_EXPIRES_IN = '7d';
+  });
+
+  describe('registerUser', () => {
+    test('hashes password, creates user, returns token', async () => {
+      const created = {
+        id: '99',
+        username: 'newuser',
+        email: 'new@test.com',
+        display_name: 'newuser',
+      };
+      bcrypt.hash.mockResolvedValue('hashed-secret');
+      User.create.mockResolvedValue(created);
+      jwt.sign.mockReturnValue('signed.jwt');
+
+      const result = await registerUser({
+        username: 'newuser',
+        email: 'new@test.com',
+        password: 'secret12',
+      });
+
+      expect(bcrypt.hash).toHaveBeenCalledWith('secret12', 10);
+      expect(User.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'newuser',
+          email: 'new@test.com',
+          passwordHash: 'hashed-secret',
+        })
+      );
+      expect(jwt.sign).toHaveBeenCalled();
+      expect(result).toEqual({ user: created, token: 'signed.jwt' });
+    });
+  });
+
+  describe('loginUser', () => {
+    test('returns user and token when credentials are valid', async () => {
+      const withHash = {
+        id: '1',
+        email: 'a@b.com',
+        password_hash: 'stored-hash',
+      };
+      const publicUser = {
+        id: '1',
+        email: 'a@b.com',
+        username: 'A',
+      };
+      User.findByEmail.mockImplementation((email, includePassword) => {
+        if (includePassword) return Promise.resolve(withHash);
+        return Promise.resolve(publicUser);
+      });
+      bcrypt.compare.mockResolvedValue(true);
+      jwt.sign.mockReturnValue('login.jwt');
+
+      const result = await loginUser({ email: 'a@b.com', password: 'ok' });
+
+      expect(bcrypt.compare).toHaveBeenCalledWith('ok', 'stored-hash');
+      expect(result).toEqual({ user: publicUser, token: 'login.jwt' });
+    });
+
+    test('throws when email is not found', async () => {
+      User.findByEmail.mockResolvedValue(undefined);
+
+      await expect(
+        loginUser({ email: 'nobody@test.com', password: 'x' })
+      ).rejects.toThrow('Invalid email or password');
+    });
+
+    test('throws when password does not match', async () => {
+      User.findByEmail.mockResolvedValue({
+        id: '1',
+        password_hash: 'h',
+      });
+      bcrypt.compare.mockResolvedValue(false);
+
+      await expect(
+        loginUser({ email: 'a@b.com', password: 'wrong' })
+      ).rejects.toThrow('Invalid email or password');
+    });
+  });
+
+  describe('getUserById', () => {
+    test('delegates to User.findById', async () => {
+      User.findById.mockResolvedValue({ id: '42' });
+      await expect(getUserById('42')).resolves.toEqual({ id: '42' });
+      expect(User.findById).toHaveBeenCalledWith('42');
+    });
+  });
+
+  describe('getAllUsers', () => {
+    test('returns empty array', async () => {
+      await expect(getAllUsers()).resolves.toEqual([]);
+    });
+  });
+
+  describe('initializeDemoAccounts', () => {
+    test('does not seed when nafisa@example.com already exists', async () => {
+      User.findByEmail.mockResolvedValue({ id: '1' });
+
+      await initializeDemoAccounts();
+
+      expect(User.findByEmail).toHaveBeenCalledWith('nafisa@example.com');
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    test('creates five demo users when none exist', async () => {
+      User.findByEmail.mockResolvedValue(null);
+      User.create.mockImplementation((u) => Promise.resolve({ id: u.id, email: u.email }));
+
+      await initializeDemoAccounts();
+
+      expect(User.create).toHaveBeenCalledTimes(5);
+      const emails = User.create.mock.calls.map((c) => c[0].email);
+      expect(emails).toEqual(
+        expect.arrayContaining([
+          'nafisa@example.com',
+          'ashraf@example.com',
+          'james@example.com',
+          'elvis@example.com',
+          'salma@example.com',
+        ])
+      );
+    });
+
+    test('swallows errors from User.findByEmail', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      User.findByEmail.mockRejectedValue(new Error('db down'));
+
+      await expect(initializeDemoAccounts()).resolves.toBeUndefined();
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for two core backend files: `services/userService.js` and `models/User.js`
- Add English test specifications in `docs/testing/`
- Configure Jest coverage (≥80% threshold per file) and `test:coverage` npm script
- Add `.github/workflows/run-backend-tests.yml` for CI on every backend change
- Update root README with backend unit test and coverage instructions

## Files changed
- `docs/testing/userService-test-spec.md` — test spec for userService
- `docs/testing/User-model-test-spec.md` — test spec for User model
- `simple-server/tests/userService.unit.test.js` — 9 isolated unit tests (mocks bcrypt, jwt, User model)
- `simple-server/tests/User.model.unit.test.js` — 19 isolated unit tests (mocks pool.query)
- `simple-server/jest.config.js` — added coverage config and per-file 80% thresholds
- `simple-server/package.json` — added `test:coverage` script
- `.github/workflows/run-backend-tests.yml` — CI with Postgres 15 service, Node 18
- `README.md` — added P5 backend unit test / coverage instructions

## Test plan
- [ ] Run `cd simple-server && npx jest userService.unit.test.js User.model.unit.test.js --coverage` — should pass with no DB
- [ ] Confirm CI workflow goes green after this PR is merged and a backend file is changed
- [ ] Merge alongside James's `p5-frontend-apiservice-tests` branch before final submission