### PR TITLE
Configure CI-gated deploy branch

### DIFF
--- a/.github/workflows/deploy-aws-amplify.yml
+++ b/.github/workflows/deploy-aws-amplify.yml
@@ -5,12 +5,39 @@ name: Deploy frontend via AWS Amplify
 on:
   push:
     branches:
-      - main
+      - deployed
   workflow_dispatch:
 
 jobs:
-  deploy-amplify:
+  test-frontend:
+    name: Run frontend CI before deploy
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint --if-present
+
+      - name: Run type checking
+        run: npm run type-check --if-present
+
+      - name: Run frontend tests
+        run: npm run test:frontend:all
+
+  deploy-amplify:
+    name: Build and deploy frontend
+    runs-on: ubuntu-latest
+    needs:
+      - test-frontend
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -4,12 +4,67 @@ name: Deploy backend to AWS Lambda
 on:
   push:
     branches:
-      - main
+      - deployed
   workflow_dispatch:
 
 jobs:
-  deploy-lambda:
+  test-backend:
+    name: Run backend CI before deploy
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres123
+          POSTGRES_DB: discord_clone
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      NODE_ENV: test
+      JWT_SECRET: your-super-secret-jwt-key-change-this-in-production
+      JWT_EXPIRES_IN: 7d
+      DATABASE_HOST: localhost
+      DATABASE_PORT: '5432'
+      DATABASE_NAME: discord_clone
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres123
+      DATABASE_URL: postgresql://postgres:postgres123@localhost:5432/discord_clone
+
+    defaults:
+      run:
+        working-directory: simple-server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: simple-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backend test suite
+        run: npm run test:coverage
+
+      - name: Run integration test suite
+        run: npm run test:integration
+
+  deploy-lambda:
+    name: Package and deploy backend
+    runs-on: ubuntu-latest
+    needs:
+      - test-backend
     defaults:
       run:
         working-directory: simple-server


### PR DESCRIPTION
## Summary
- retarget deploy workflows so pushes to `deployed` trigger release automation instead of `main`
- add frontend CI gating before Amplify deploy runs
- add backend and integration CI gating before Lambda deploy runs

## Co-author
- ElvisValcarcel (@ElvisValcarcel)

## Test plan
- [x] Validate updated workflow YAML parses locally
- [ ] Merge into `deployed` and confirm both deploy workflows trigger in GitHub Actions
- [ ] Verify Amplify deploy succeeds with the configured app and branch secrets
- [ ] Verify Lambda package and deploy succeeds with the configured AWS secrets